### PR TITLE
Referring to the official Linux download links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ $ swarm up --var=domain=helloworld-$USER.gigantic.io
 
 ## Linux 
 
+See http://docs.giantswarm.io/reference/installation/#linux for Linux installation instructions.
+
 ```
 $ git clone https://github.com/giantswarm/helloworld.git && cd helloworld
-$ curl -O http://downloads.giantswarm.io/swarm/clients/0.8.0/swarm-0.8.0-linux-amd64.tar.gz
-$ tar -xzf swarm-0.8.0-linux-amd64.tar.gz swarm
 $ ./swarm login 
 ```
 (Enter your Giant Swarm credentials)


### PR DESCRIPTION
The Linux install instructions were outdated. Referring to our official docs so we don't have to update this readme with every release.

RFR @marians 