### PR TITLE
Use alpine with static binary and latest go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:ubuntu-14.04
+FROM alpine:3.4
 
 ADD ./helloworld /usr/bin/
 ADD content /content

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,10 @@ $(PROJECT): $(SOURCE)
 		-e GOPATH=/usr/code/.gobuild \
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
+		-e CGO_ENABLED=0 \
 		-w /usr/code \
-		golang:1.4-cross \
-		go build -a -o $(PROJECT)
+		golang:1.7.3 \
+		go build -a -installsuffix cgo -o $(PROJECT)
 
 docker-build: $(PROJECT)
 	docker build -t $(USERNAME)/$(PROJECT) .

--- a/content/index.html
+++ b/content/index.html
@@ -40,7 +40,8 @@
     font-weight: 400;
   }
   h1, p {
-    text-align: center
+    text-align: center;
+    line-height:  1.8em;
   }
   a {
     color: #fff;


### PR DESCRIPTION
- Use the more popular alpine base image
- compile statically to run on alpine and any other linux
- use Golang version 1.7.3 (instead of 1.4)

RFR @giantswarm/team-l8