### PR TITLE
run as non root

### DIFF
--- a/helloworld-manifest.yaml
+++ b/helloworld-manifest.yaml
@@ -29,6 +29,8 @@ spec:
         app: helloworld
       namespace: default
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: helloworld
         image: giantswarm/helloworld:latest


### PR DESCRIPTION
Fixes errors like:

    Warning  Failed     20s (x8 over 105s)  kubelet, ip-10-1-8-51.eu-central-1.compute.internal  Error: container has runAsNonRoot and image will run as root