### PR TITLE
Moving namespace to the correct part of the deployment object

### DIFF
--- a/helloworld-manifest.yaml
+++ b/helloworld-manifest.yaml
@@ -18,6 +18,7 @@ metadata:
   name: helloworld
   labels:
     app: helloworld
+  namespace: default
 spec:
   replicas: 2
   selector:
@@ -27,7 +28,6 @@ spec:
     metadata:
       labels:
         app: helloworld
-      namespace: default
     spec:
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION
Hello! 

It appears specifying a namespace for a deployment outside of the metadata section has no effect -- The pods for this deployment will still spawn on the deployment's namespace (in this case, the default one)

Even having a deployment on namespace A and intentionally attempting to spawn it's pods on namespace B will still have everything launch on namespace A.

Tested on Kubernetes v1.14.3 on a certain super secret cluster set up by Václav.


