### PR TITLE
Change to ClusterIP

### DIFF
--- a/helloworld-manifest.yaml
+++ b/helloworld-manifest.yaml
@@ -6,7 +6,7 @@ metadata:
     app: helloworld
   namespace: default
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - port: 8080
   selector:


### PR DESCRIPTION
It doesn't make much sense to have nodeport when our nodes are on private subnet, we will need the Ingress anyway. WDYT?