### PR TITLE
Add missing nginx ingressClassName

### DIFF
--- a/helloworld-manifest.yaml
+++ b/helloworld-manifest.yaml
@@ -85,6 +85,7 @@ metadata:
   name: helloworld
   namespace: default
 spec:
+  ingressClassName: nginx
   rules:
   # Change the host to match your cluster base domain.
   # See https://docs.giantswarm.io/guides/accessing-services-from-the-outside/ for details.


### PR DESCRIPTION
With the current version, when testing the connectivity, e.g. by visiting http://helloworld.p8ok5.k8s.gauss.eu-west-1.aws.gigantic.io, the user gets a 404 error message.

The problem is related to a missing Ingress Class attribute, as per the nginx pods' error message:
```
"Ignoring ingress because of error while validating ingress class" ingress="default/helloworld" error="ingress does not contain a valid IngressClass"
```

This PR adds the missing value.