### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.0.0
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   all:
@@ -13,14 +13,12 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          name: push-helloworld-to-quay
-          image: "quay.io/giantswarm/helloworld"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
           requires:
             - go-build-helloworld
-          # Needed to trigger job also on git tag.
+            - hold-push-helloworld-to-aliyun-pr
           filters:
             tags:
               only: /^v.*/
@@ -34,28 +32,3 @@ workflows:
             branches:
               ignore: master
 
-      - architect/push-to-docker:
-          name: push-helloworld-to-aliyun-pr
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/helloworld"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          # Push to Aliyun should execute for non-master branches only once manually approved.
-          requires:
-            - hold-push-helloworld-to-aliyun-pr
-          # Needed to prevent job being triggered for master branch.
-          filters:
-            branches:
-              ignore: master
-
-      # Push to Aliyun should execute without manual approval on master.
-      - architect/push-to-docker:
-          name: push-helloworld-to-aliyun-master
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/helloworld"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          requires:
-            - go-build-helloworld
-          # Needed to trigger job only on merge to master.
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
   all:
     jobs:
       - architect/go-build:
-          name: go-build-helloworld
+          name: go-build
           binary: helloworld
           filters:
             # Trigger job also on git tag.
@@ -17,18 +17,8 @@ workflows:
           context: architect
           name: push-to-registries
           requires:
-            - go-build-helloworld
-            - hold-push-helloworld-to-aliyun-pr
+            - go-build
+          
           filters:
             tags:
               only: /^v.*/
-
-      - hold-push-helloworld-to-aliyun-pr:
-          type: approval
-          requires:
-            - go-build-helloworld
-          # Needed to prevent job from being triggered on master branch.
-          filters:
-            branches:
-              ignore: master
-

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/giantswarm/helloworld
 
-go 1.16
+go 1.19

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	go func() {
 		log.Println("Starting up at :8080")
-		log.Fatal(http.ListenAndServe(":8080", nil))
+		log.Fatal(http.ListenAndServe(":8080", nil)) //nolint:gosec
 	}()
 
 	// Handle SIGTERM.


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [x] Assign this PR to yourself
- [x] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [x] Double-check the job dependecies (`requires`)
- [x] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!