### PR TITLE
Use gsoci (and other updates)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.35.5
+  architect: giantswarm/architect@4.35.6
 
 workflows:
   all:
@@ -18,7 +18,6 @@ workflows:
           name: push-to-registries
           requires:
             - go-build
-          
           filters:
             tags:
               only: /^v.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/golang:1.16.7-alpine3.14 AS builder
+FROM quay.io/giantswarm/golang:1.19-alpine3.19 AS builder
 
 WORKDIR /project
 
@@ -7,7 +7,7 @@ COPY go.mod /project/
 
 RUN go build .
 
-FROM quay.io/giantswarm/alpine:3.14.1
+FROM quay.io/giantswarm/alpine:3.19
 
 # Add our static content
 ADD content /content

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/golang:1.19-alpine3.19 AS builder
+FROM quay.io/giantswarm/golang:1.21.5-alpine3.18 AS builder
 
 WORKDIR /project
 
@@ -7,7 +7,7 @@ COPY go.mod /project/
 
 RUN go build .
 
-FROM quay.io/giantswarm/alpine:3.19
+FROM quay.io/giantswarm/alpine:3.18.5
 
 # Add our static content
 ADD content /content

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 .PHONY=build
 
 build:
-	docker build -t quay.io/giantswarm/helloworld:latest .
+	docker build -t gsoci.azurecr.io/giantswarm/helloworld:latest .
 
 run: build
-	docker run -p 8080:8080 -ti --rm quay.io/giantswarm/helloworld:latest
+	docker run -p 8080:8080 -ti --rm gsoci.azurecr.io/giantswarm/helloworld:latest
 
 clean:
-	docker rmi quay.io/giantswarm/helloworld:latest
+	docker rmi gsoci.azurecr.io/giantswarm/helloworld:latest

--- a/helloworld-manifest.yaml
+++ b/helloworld-manifest.yaml
@@ -43,7 +43,7 @@ spec:
         runAsUser: 1000
       containers:
       - name: helloworld
-        image: quay.io/giantswarm/helloworld:latest
+        image: gsoci.azurecr.io/giantswarm/helloworld:latest
         ports:
         - containerPort: 8080
         livenessProbe:


### PR DESCRIPTION
- Use gsoci.azurecr.io as the registry to pull from
- Update Go builder image and alpine base image
- Update architect-orb