### PR TITLE
feat(ci): support linux/arm64 with container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@dev:5fb3462adbc8a3c7299036c92b1f11c0d4e59636
+  architect: giantswarm/architect@8.0.2
 
 workflows:
   all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,14 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@6.15.0
+  architect: giantswarm/architect@8.0.0
 
 workflows:
   all:
     jobs:
     - architect/go-build:
-        name: go-build
+        matrix:
+          parameters:
+            architecture: ["linux/amd64", "linux/arm64"]
         binary: helloworld
         filters:
             # Trigger job also on git tag.
@@ -16,8 +18,10 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        image: giantswarm/helloworld
+        multiarch: true
         requires:
-        - go-build
+        - architect/go-build
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.0.0
+  architect: giantswarm/architect@dev:5fb3462adbc8a3c7299036c92b1f11c0d4e59636
 
 workflows:
   all:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM gsoci.azurecr.io/giantswarm/golang:1.25.5-alpine3.21 AS builder
-
-WORKDIR /project
-
-COPY main.go /project/
-COPY go.mod /project/
-COPY go.sum /project/
-
-RUN go build .
+FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3 AS binary-selector
+ARG TARGETPLATFORM
+COPY helloworld-* /binaries/
+RUN case "$TARGETPLATFORM" in \
+      "linux/amd64") cp /binaries/helloworld-linux-amd64 /bin/helloworld ;; \
+      "linux/arm64") cp /binaries/helloworld-linux-arm64 /bin/helloworld ;; \
+      *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
+    esac
 
 FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3
 
@@ -14,7 +13,7 @@ FROM gsoci.azurecr.io/giantswarm/alpine:3.23.3
 ADD content /content
 
 # Add our binary
-COPY --from=builder /project/helloworld /helloworld
+COPY --from=binary-selector /bin/helloworld /helloworld
 
 EXPOSE 8080
 


### PR DESCRIPTION
This PR wants to add linux/arm64 support to the container image.

To achieve that, we also upgrade to architect-orb v8.0.2.