### PR TITLE
feat: add /echo endpoint with optional response delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `/echo` endpoint that echoes request details as JSON, with an optional `?delay` query param to delay the response.
+
 ## [0.6.0] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The server starts on http://localhost:8080.
 | Path       | Description                          |
 |------------|--------------------------------------|
 | `/`        | Static HTML welcome page             |
+| `/echo`    | Echoes the request (method, path, query, headers, body) as JSON, with `received_at`/`responded_at` timestamps. Add `?delay=2s` (any Go duration) to delay the response. |
 | `/healthz` | Health check (returns `200 OK`)      |
 | `/metrics` | Prometheus metrics                   |
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -55,6 +57,7 @@ func main() {
 	http.Handle("/", loggingHandler(fileHandler))
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/healthz", healthzHandler)
+	http.Handle("/echo", loggingHandler(http.HandlerFunc(echoHandler)))
 
 	go func() {
 		slog.Info("Starting up at :8080")
@@ -85,5 +88,71 @@ func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	_, err := io.WriteString(w, "OK\n")
 	if err != nil {
 		slog.Error("Error in io.WriteString", "error", err)
+	}
+}
+
+// echoResponse describes the request echoed back by echoHandler.
+type echoResponse struct {
+	ReceivedAt  time.Time           `json:"received_at"`
+	RespondedAt time.Time           `json:"responded_at"`
+	Delay       string              `json:"delay"`
+	Method      string              `json:"method"`
+	Path        string              `json:"path"`
+	Query       map[string][]string `json:"query"`
+	Host        string              `json:"host"`
+	RemoteAddr  string              `json:"remote_addr"`
+	Proto       string              `json:"proto"`
+	Headers     map[string][]string `json:"headers"`
+	Body        string              `json:"body"`
+}
+
+// Echo endpoint: echoes back the request details as JSON, optionally delaying
+// the response by the duration given in the "delay" query param (e.g. ?delay=2s).
+func echoHandler(w http.ResponseWriter, r *http.Request) {
+	receivedAt := time.Now().UTC()
+
+	var delay time.Duration
+	if raw := r.URL.Query().Get("delay"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil || d < 0 {
+			http.Error(w, "invalid delay: expected a non-negative Go duration like 500ms, 2s or 1m", http.StatusBadRequest)
+			return
+		}
+		delay = d
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.Error("Error reading request body", "error", err)
+		http.Error(w, "error reading request body", http.StatusBadRequest)
+		return
+	}
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			slog.Info("Echo request cancelled during delay", "error", r.Context().Err())
+			return
+		}
+	}
+
+	resp := echoResponse{
+		ReceivedAt:  receivedAt,
+		RespondedAt: time.Now().UTC(),
+		Delay:       delay.String(),
+		Method:      r.Method,
+		Path:        r.URL.Path,
+		Query:       r.URL.Query(),
+		Host:        r.Host,
+		RemoteAddr:  r.RemoteAddr,
+		Proto:       r.Proto,
+		Headers:     r.Header,
+		Body:        string(body),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("Error encoding echo response", "error", err)
 	}
 }


### PR DESCRIPTION
## What

Adds a new `/echo` endpoint to the helloworld server.

- Returns a JSON echo of the incoming request: `method`, `path`, `query`, `host`, `remote_addr`, `proto`, `headers`, and `body`.
- Includes `received_at` and `responded_at` timestamps.
- Optional `?delay=2s` query param (any Go duration like `500ms`, `1m`) delays the response. The delay respects client disconnect/shutdown via the request context.
- Invalid or negative durations return `400`.

The endpoint is wrapped in the existing `loggingHandler`, so it is logged and counted in `http_requests_total` like other routes.

## Why

Useful for exercising client timeouts, inspecting what a client actually sends, and driving latency/observability dashboards.

## Testing

- `go build ./...` and `go vet ./...` pass.
- `curl "localhost:8080/echo?delay=2s"` returns after ~2s with timestamps 2s apart.
- POST body is echoed; invalid delay returns `400`; client disconnect logs cancellation cleanly with no panic.
- `/healthz` and `/metrics` unaffected.