### PR TITLE
feat: add opt-in memory leak injector for staged OOMKill demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add `/echo` endpoint that echoes request details as JSON, with an optional `?delay` query param to delay the response.
+- Add an opt-in, off-by-default memory leak injector for staging a reproducible OOMKill-on-a-loop failure (e.g. for demos and testing). Configured via `MEMORY_LEAK_ENABLED`, `MEMORY_LEAK_RATE_BYTES_PER_SEC` and `MEMORY_LEAK_GRACE_PERIOD`, with `/leak/stop`, `/leak/start` and `/leak/status` runtime controls and a `helloworld_memory_leaked_bytes` metric. When disabled (the default) behaviour is unchanged.
 
 ## [0.6.0] - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,48 @@ The server starts on http://localhost:8080.
 | `/healthz` | Health check (returns `200 OK`)      |
 | `/metrics` | Prometheus metrics                   |
 
+## Staged failure injection (memory leak)
+
+The app ships with an **opt-in, off-by-default** memory leak so it can be used as
+a reproducible failure fixture (for example, to demo an SRE agent diagnosing an
+`OOMKilled` crash loop). It is disabled unless explicitly enabled, and when
+disabled the app behaves exactly as it always has.
+
+When enabled it allocates and *touches* memory at a steady rate after a short
+startup grace period, so the resident/working set climbs linearly until the
+container hits its memory limit and the kubelet OOMKills it. HTTP probes keep
+passing right up to the kill. On startup it logs a `WARN` line so the staged
+failure is obvious to anyone inspecting the environment.
+
+Configuration (environment variables):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMORY_LEAK_ENABLED` | `false` | Set to a truthy value (`true`, `1`, …) to enable the leak. |
+| `MEMORY_LEAK_RATE_BYTES_PER_SEC` | `1048576` (1 MiB/s) | Steady leak rate, in bytes per second. |
+| `MEMORY_LEAK_GRACE_PERIOD` | `30s` | Delay before leaking starts, so the pod reaches `Ready` first. Any Go duration. |
+
+> **Note:** do not set `GOMEMLIMIT` when using this. A soft memory limit would
+> make the Go runtime constrain itself instead of letting the kubelet OOMKill
+> the container, which defeats the purpose.
+
+Runtime controls (only served when the leak is enabled):
+
+| Path | Description |
+|------|-------------|
+| `/leak/stop` | Pause allocation; the resident set plateaus and the pod stays alive. |
+| `/leak/start` | Resume allocation. |
+| `/leak/status` | Return the current state as JSON (`active`, `leaked_bytes`, `rate_bytes_per_sec`, `grace_period`). |
+
+The `helloworld_memory_leaked_bytes` gauge (exposed on `/metrics`, and only
+present when the leak is enabled) reports how many bytes have been leaked so far.
+
+When deployed via the [hello-world-app](https://github.com/giantswarm/hello-world-app)
+chart, just set `crash.enabled: true` (sane defaults for the rate and grace period
+are applied for you, and can be overridden via `crash.rateBytesPerSec` and
+`crash.gracePeriod`). These environment variables can also be set directly through
+the chart's generic `extraEnv` value.
+
 ## Learn more
 
 To learn more about Giant Swarm, visit https://www.giantswarm.io/.

--- a/leak.go
+++ b/leak.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Environment variables controlling the deliberately-staged memory leak.
+//
+// The leak is OFF unless memoryLeakEnabledEnv is set to a truthy value
+// (as understood by strconv.ParseBool), so the default behaviour of the
+// application is completely unaffected. This is intentionally an opt-in test
+// fixture for reproducing an OOMKill-on-a-loop failure, not a real bug.
+const (
+	memoryLeakEnabledEnv = "MEMORY_LEAK_ENABLED"
+	memoryLeakRateEnv    = "MEMORY_LEAK_RATE_BYTES_PER_SEC"
+	memoryLeakGraceEnv   = "MEMORY_LEAK_GRACE_PERIOD"
+)
+
+const (
+	// defaultMemoryLeakRateBytesPerSec is used when the leak is enabled but no
+	// valid rate is configured. 1 MiB/s.
+	defaultMemoryLeakRateBytesPerSec = 1 << 20
+	// defaultMemoryLeakGracePeriod gives the pod time to pass its readiness
+	// probe and reach Ready before memory starts climbing.
+	defaultMemoryLeakGracePeriod = 30 * time.Second
+	// leakPageSize is the stride, in bytes, at which freshly allocated memory
+	// is written to. Touching one byte per OS page faults the whole page in so
+	// it becomes resident; allocated-but-untouched memory would not show up in
+	// container_memory_working_set_bytes.
+	leakPageSize = 4096
+	// leakInterval is how often memory is allocated. A sub-second interval
+	// keeps the growth curve smooth and linear rather than steppy/bursty.
+	leakInterval = 100 * time.Millisecond
+)
+
+// memoryLeaker holds the state of the running leak so it can be inspected and
+// controlled at runtime.
+type memoryLeaker struct {
+	rateBytesPerSec int64
+	gracePeriod     time.Duration
+
+	// active reports whether allocation is currently happening. It can be
+	// toggled at runtime via the control endpoints without a redeploy.
+	active atomic.Bool
+
+	mu     sync.Mutex
+	blocks [][]byte // retained references are what keep the pages resident
+	leaked int64
+
+	gauge prometheus.Gauge
+}
+
+// setupMemoryLeak wires up the deliberately-staged memory leak when it is
+// enabled via the environment.
+//
+// When disabled (the default) it is a no-op and leaves the application
+// byte-for-byte identical to its previous behaviour: no goroutine is started,
+// no metric is registered, no control endpoints are added and nothing is
+// logged. It must be called before the HTTP server starts, as it registers
+// handlers on http.DefaultServeMux.
+func setupMemoryLeak() {
+	enabled, _ := strconv.ParseBool(os.Getenv(memoryLeakEnabledEnv))
+	if !enabled {
+		return
+	}
+
+	rate := int64(defaultMemoryLeakRateBytesPerSec)
+	if raw := os.Getenv(memoryLeakRateEnv); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			rate = v
+		} else {
+			slog.Warn("Invalid memory leak rate, using default",
+				"env", memoryLeakRateEnv, "value", raw,
+				"default_bytes_per_sec", defaultMemoryLeakRateBytesPerSec)
+		}
+	}
+
+	grace := time.Duration(defaultMemoryLeakGracePeriod)
+	if raw := os.Getenv(memoryLeakGraceEnv); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d >= 0 {
+			grace = d
+		} else {
+			slog.Warn("Invalid memory leak grace period, using default",
+				"env", memoryLeakGraceEnv, "value", raw,
+				"default", defaultMemoryLeakGracePeriod.String())
+		}
+	}
+
+	l := &memoryLeaker{
+		rateBytesPerSec: rate,
+		gracePeriod:     grace,
+		gauge: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "helloworld_memory_leaked_bytes",
+			Help: "Bytes deliberately leaked by the staged memory-leak injector. Only present when the leak is enabled.",
+		}),
+	}
+
+	// Make it obvious to anyone inspecting the environment that this failure is
+	// staged, not a real bug.
+	slog.Warn("Memory leak injection is DELIBERATELY ENABLED (staged failure for demos/testing)",
+		"rate_bytes_per_sec", rate,
+		"grace_period", grace.String())
+
+	// Runtime controls so the leak can be stopped or resumed mid-session
+	// without a redeploy, e.g. to stabilise the pod if a recording take goes
+	// wrong.
+	http.HandleFunc("/leak/stop", l.handleStop)
+	http.HandleFunc("/leak/start", l.handleStart)
+	http.HandleFunc("/leak/status", l.handleStatus)
+
+	go l.run()
+}
+
+// run performs the leak: after the startup grace period it allocates and
+// touches memory at a steady cadence, retaining every allocation so the pages
+// stay resident until the kubelet OOMKills the container.
+func (l *memoryLeaker) run() {
+	if l.gracePeriod > 0 {
+		time.Sleep(l.gracePeriod)
+	}
+	l.active.Store(true)
+
+	// Bytes to allocate per tick, derived from the configured rate so that the
+	// long-run growth matches rateBytesPerSec regardless of leakInterval.
+	perTick := int(float64(l.rateBytesPerSec) * leakInterval.Seconds())
+	if perTick < leakPageSize {
+		perTick = leakPageSize
+	}
+
+	ticker := time.NewTicker(leakInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if !l.active.Load() {
+			// Paused via /leak/stop: memory plateaus and the pod stays alive.
+			continue
+		}
+		l.allocate(perTick)
+	}
+}
+
+// allocate grabs n bytes, touches every page so they become resident, and
+// retains the reference so the memory is never reclaimed.
+func (l *memoryLeaker) allocate(n int) {
+	b := make([]byte, n)
+	// Write a non-zero byte to every page (and the final byte) so each page is
+	// faulted in and counts towards the resident/working set. A non-zero value
+	// avoids any zero-page deduplication.
+	for i := 0; i < n; i += leakPageSize {
+		b[i] = 0xA5
+	}
+	b[n-1] = 0xA5
+
+	l.mu.Lock()
+	l.blocks = append(l.blocks, b)
+	l.leaked += int64(n)
+	leaked := l.leaked
+	l.mu.Unlock()
+
+	l.gauge.Set(float64(leaked))
+}
+
+func (l *memoryLeaker) handleStop(w http.ResponseWriter, r *http.Request) {
+	if l.active.Swap(false) {
+		slog.Warn("Memory leak paused via control endpoint", "remote_addr", r.RemoteAddr)
+	}
+	l.writeStatus(w)
+}
+
+func (l *memoryLeaker) handleStart(w http.ResponseWriter, r *http.Request) {
+	if !l.active.Swap(true) {
+		slog.Warn("Memory leak resumed via control endpoint", "remote_addr", r.RemoteAddr)
+	}
+	l.writeStatus(w)
+}
+
+func (l *memoryLeaker) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	l.writeStatus(w)
+}
+
+func (l *memoryLeaker) writeStatus(w http.ResponseWriter) {
+	l.mu.Lock()
+	leaked := l.leaked
+	l.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"active":             l.active.Load(),
+		"leaked_bytes":       leaked,
+		"rate_bytes_per_sec": l.rateBytesPerSec,
+		"grace_period":       l.gracePeriod.String(),
+	}); err != nil {
+		slog.Error("Error encoding leak status response", "error", err)
+	}
+}

--- a/leak.go
+++ b/leak.go
@@ -69,7 +69,18 @@ type memoryLeaker struct {
 // logged. It must be called before the HTTP server starts, as it registers
 // handlers on http.DefaultServeMux.
 func setupMemoryLeak() {
-	enabled, _ := strconv.ParseBool(os.Getenv(memoryLeakEnabledEnv))
+	rawEnabled := os.Getenv(memoryLeakEnabledEnv)
+	enabled, err := strconv.ParseBool(rawEnabled)
+	if err != nil {
+		// Distinguish "unset" (silently stay disabled, the default) from a
+		// non-empty but unparseable value, which is almost always a mistake and
+		// the top reason a staged failure "isn't firing".
+		if rawEnabled != "" {
+			slog.Warn("Invalid memory leak enabled flag, leak disabled",
+				"env", memoryLeakEnabledEnv, "value", rawEnabled)
+		}
+		return
+	}
 	if !enabled {
 		return
 	}
@@ -130,21 +141,26 @@ func (l *memoryLeaker) run() {
 	}
 	l.active.Store(true)
 
-	// Bytes to allocate per tick, derived from the configured rate so that the
-	// long-run growth matches rateBytesPerSec regardless of leakInterval.
-	perTick := int(float64(l.rateBytesPerSec) * leakInterval.Seconds())
-	if perTick < leakPageSize {
-		perTick = leakPageSize
-	}
+	// Bytes owed per tick, derived from the configured rate. We accumulate a
+	// fractional remainder across ticks and only allocate whole bytes, so the
+	// long-run rate matches rateBytesPerSec exactly even for rates that work
+	// out to less than one byte (or less than a page) per tick.
+	perTick := float64(l.rateBytesPerSec) * leakInterval.Seconds()
+	var owed float64
 
 	ticker := time.NewTicker(leakInterval)
 	defer ticker.Stop()
 	for range ticker.C {
 		if !l.active.Load() {
 			// Paused via /leak/stop: memory plateaus and the pod stays alive.
+			// Time spent paused does not accrue, so resuming is not bursty.
 			continue
 		}
-		l.allocate(perTick)
+		owed += perTick
+		if n := int(owed); n > 0 {
+			l.allocate(n)
+			owed -= float64(n)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -59,6 +59,10 @@ func main() {
 	http.HandleFunc("/healthz", healthzHandler)
 	http.Handle("/echo", loggingHandler(http.HandlerFunc(echoHandler)))
 
+	// Opt-in, off-by-default staged memory leak (see leak.go). No-op unless
+	// explicitly enabled via the environment.
+	setupMemoryLeak()
+
 	go func() {
 		slog.Info("Starting up at :8080")
 		if err := http.ListenAndServe(":8080", nil); err != nil { //nolint:gosec


### PR DESCRIPTION
## What

Adds an **opt-in, off-by-default** memory leak so the app can be used as a reproducible failure fixture — e.g. to demo an SRE agent diagnosing an `OOMKilled` crash loop. When disabled (the default), behaviour is byte-for-byte unchanged.

## Behaviour when enabled

- Allocates and **touches** memory at a steady rate after a startup grace period, so the resident/working set climbs linearly until the kubelet OOMKills the container (exit 137). It deliberately keeps the memory resident (writes one byte per page) so `container_memory_working_set_bytes` actually rises.
- HTTP probes keep passing right up to the kill.
- Logs a `WARN` line on startup so the staged failure is obvious to anyone inspecting the environment.

## Configuration (environment variables)

| Variable | Default | Description |
|----------|---------|-------------|
| `MEMORY_LEAK_ENABLED` | `false` | Truthy value enables the leak. |
| `MEMORY_LEAK_RATE_BYTES_PER_SEC` | `1048576` (1 MiB/s) | Steady leak rate, bytes/sec. |
| `MEMORY_LEAK_GRACE_PERIOD` | `30s` | Delay before leaking starts, so the pod reaches `Ready` first. |

> Do not set `GOMEMLIMIT` alongside this — a soft memory limit makes the Go runtime constrain itself instead of letting the kubelet OOMKill the container.

## Runtime controls (only served when enabled)

- `POST/GET /leak/stop` — pause allocation; resident set plateaus, pod stays alive.
- `POST/GET /leak/start` — resume.
- `GET /leak/status` — JSON state (`active`, `leaked_bytes`, `rate_bytes_per_sec`, `grace_period`).

A `helloworld_memory_leaked_bytes` gauge is exposed on `/metrics` (only present when enabled).

## Measured behaviour

At 1 MiB/s against a 128Mi limit, the container is OOMKilled ~128–131 s after start (~125 s climb after grace), repeatably (exit 137). Verified in a kind cluster: `reason: OOMKilled`, restart count increments each cycle, `/healthz` returns 200 up to the kill, and the cadvisor working set shows a clean linear sawtooth.

## Notes

- Default `/metrics` output and all existing endpoints are unchanged when the leak is disabled (no metric registered, no `/leak` routes added, nothing logged).
- Deploy via the [hello-world-app](https://github.com/giantswarm/hello-world-app) chart with `crash.enabled: true` (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)